### PR TITLE
Fix get node return null on state not avaliable

### DIFF
--- a/lib/orchester.ts
+++ b/lib/orchester.ts
@@ -47,7 +47,7 @@ const roundGetNode = (sequencer: Sequencer, nodesRepository: Repository<NodeRegi
     return nodesRepository.getOne(sequencer.next())
 }
 
-const checkNodeIsNotAvaliable = (node: NodeRegistre) => node.state === NODE_STATES.UP
+const checkNodeIsNotAvaliable = (node: Partial<NodeRegistre>) => node.state === NODE_STATES.UP
     || node.state === NODE_STATES.STOPPED
     || node.state === NODE_STATES.DOING_SOMETHING
 
@@ -56,21 +56,15 @@ const handleGetReplicasNodes = (sequencer: Sequencer
     , count = 0) => {
     const node = roundGetNode(sequencer, nodesRepository)
     const len = sequencer.queue.length
-    if (checkNodeIsNotAvaliable(node)) {
-        if (len > count) return handleGetReplicasNodes(sequencer, nodesRepository, ++count)
-        else return null
+    if (len > count) {
+        return handleGetReplicasNodes(sequencer, nodesRepository, ++count)
     }
 
     return node
 }
 
 const handleGetNode = (sequencer: Sequencer, nodesRepository: Repository<NodeRegistre>) => {
-    const node = nodesRepository.getOne(sequencer.queue[0])
-    if (node && checkNodeIsNotAvaliable(node)) {
-        return null
-    }
-
-    return node
+    return nodesRepository.getOne(sequencer.queue[0])
 }
 
 const addNodeAwaiterToStack = (nodeAwaitStack: NodeAwaitStack) => (unique: symbol, id: string, invoker: FnNodeAwaiterInvoker) => {
@@ -133,6 +127,7 @@ const onAddNodeRegistre = (nodesRepository: Repository<NodeRegistre>
     , nodePoolStack: NodePoolStack
     , nodeAwaitStack: NodeAwaitStack
     , nodeRegistre: Partial<NodeRegistre>) => {
+    if (checkNodeIsNotAvaliable(nodeRegistre)) return
     onRegistreHandlePoolStack(nodePoolStack, nodeRegistre)
     onRegistreHandleAwaitStack(nodesRepository, nodePoolStack, nodeAwaitStack, nodeRegistre)
 }

--- a/test/nodePicker.test.ts
+++ b/test/nodePicker.test.ts
@@ -82,32 +82,32 @@ test('check get not avaliable node', async (t) => {
     t.is(pickError.message, err.message(pickId))
 })
 
-test('check get not avaliable node whit 2 replicas off', async (t) => {
-    const foo = create('foo', { pickTimeoutOut: 500 })
-    const bar = createNodeRegistre('bar', NODE_STATES.UP)
-    const bar1 = createNodeRegistre('bar1', NODE_STATES.UP, { is: false, of: 'bar' })
-    const bar2 = createNodeRegistre('bar2', NODE_STATES.RUNNING, { is: false, of: 'bar' })
+test('check get not avaliable whit one replica off', async (t) => {
+    const foo = create('foo')
+    const bar = createNodeRegistre('bar', NODE_STATES.UP, { is: false, of: null })
+    const bar1 = createNodeRegistre('bar1', NODE_STATES.RUNNING, { is: true, of: 'bar' })
+    const bar2 = createNodeRegistre('bar2', NODE_STATES.RUNNING, { is: true, of: 'bar' })
 
     foo.nodesRepository.add(bar.index, bar)
-    foo.nodesRepository.add(bar.index, bar1)
-    foo.nodesRepository.add(bar.index, bar2)
+    foo.nodesRepository.add(bar1.index, bar1)
+    foo.nodesRepository.add(bar2.index, bar2)
 
     const pick = await foo.nodePicker.pick('bar')
-    t.is(pick.id, bar.id)
+    t.is(pick.id, bar1.id)
     t.is(pick.state, NODE_STATES.RUNNING)
 })
 
-test('check get not avaliable whit one replica off', async (t) => {
-    const foo = create('foo', { pickTimeoutOut: 500 })
-    const bar = createNodeRegistre('bar', NODE_STATES.RUNNING)
-    const bar1 = createNodeRegistre('bar1', NODE_STATES.UP, { is: false, of: 'bar' })
-    const bar2 = createNodeRegistre('bar2', NODE_STATES.RUNNING, { is: false, of: 'bar' })
+test('check get not avaliable node whit 2 replicas off', async (t) => {
+    const foo = create('foo')
+    const bar = createNodeRegistre('bar', NODE_STATES.UP, { is: false, of: null })
+    const bar1 = createNodeRegistre('bar1', NODE_STATES.RUNNING, { is: true, of: 'bar' })
+    const bar2 = createNodeRegistre('bar2', NODE_STATES.STOPPED, { is: true, of: 'bar' })
 
     foo.nodesRepository.add(bar.index, bar)
-    foo.nodesRepository.add(bar.index, bar1)
-    foo.nodesRepository.add(bar.index, bar2)
+    foo.nodesRepository.add(bar1.index, bar1)
+    foo.nodesRepository.add(bar2.index, bar2)
 
     const pick = await foo.nodePicker.pick('bar')
-    t.is(pick.id, bar.id)
+    t.is(pick.id, bar1.id)
     t.is(pick.state, NODE_STATES.RUNNING)
 })

--- a/test/nodePicker.test.ts
+++ b/test/nodePicker.test.ts
@@ -82,9 +82,24 @@ test('check get not avaliable node', async (t) => {
     t.is(pickError.message, err.message(pickId))
 })
 
-test('check get not avaliable whit replica nodes', async (t) => {
+test('check get not avaliable node whit 2 replicas off', async (t) => {
     const foo = create('foo', { pickTimeoutOut: 500 })
     const bar = createNodeRegistre('bar', NODE_STATES.UP)
+    const bar1 = createNodeRegistre('bar1', NODE_STATES.UP, { is: false, of: 'bar' })
+    const bar2 = createNodeRegistre('bar2', NODE_STATES.RUNNING, { is: false, of: 'bar' })
+
+    foo.nodesRepository.add(bar.index, bar)
+    foo.nodesRepository.add(bar.index, bar1)
+    foo.nodesRepository.add(bar.index, bar2)
+
+    const pick = await foo.nodePicker.pick('bar')
+    t.is(pick.id, bar.id)
+    t.is(pick.state, NODE_STATES.RUNNING)
+})
+
+test('check get not avaliable whit one replica off', async (t) => {
+    const foo = create('foo', { pickTimeoutOut: 500 })
+    const bar = createNodeRegistre('bar', NODE_STATES.RUNNING)
     const bar1 = createNodeRegistre('bar1', NODE_STATES.UP, { is: false, of: 'bar' })
     const bar2 = createNodeRegistre('bar2', NODE_STATES.RUNNING, { is: false, of: 'bar' })
 


### PR DESCRIPTION
Ahora el orquestador ignora todos los nodos no disponibles, desde el primer momento en que estos se registran. A este no le deben interesar los nodos que no puedan ser obtenidos. Esto mejora el algoritmo de selección de nodos, ademas elimina el problema, que presentaba cuando se solicitaba un nodo en estado no disponible, el cual devolvía un null.